### PR TITLE
Proof of concept BedPe + BedGraph viewers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pyc
+__pycache__
+*.pyo
+*.egg-info
+.idea
+.eggs
+

--- a/glue_genomics_viewers/data.py
+++ b/glue_genomics_viewers/data.py
@@ -1,0 +1,304 @@
+from dataclasses import dataclass
+from subprocess import check_call, PIPE, Popen
+import os
+import logging
+
+import pandas as pd
+from glue.core import Data
+
+from .subsets import GenomicRangeSubsetState
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GenomeRange:
+    chrom: str
+    start: int
+    end: int
+
+
+@dataclass
+class BedGraph:
+    """Utility to aggregate, index and query BedGraph files.
+
+    This will progressively downsample an original dataset, creating a collection
+    of aggregation files located in a `.glue_index` folder parallel to the original file.
+
+    The current implementation is restricted to simple, single-attribute files.
+
+    Parameters
+    ----------
+    path: Path to a local BedGraph file
+    downsample_factor: How much each successive aggregation downsamples the previous pass.
+    depth: How many passes of downsampling to create and index.
+    """
+    path: str
+    downsample_factor = 10
+    depth = 5
+
+    def index(self):
+        """
+        Aggregate and downsample raw data.
+
+        This operation is currently very slow (10+ minutes / GB)
+        """
+        os.mkdirs(os.path.join(self.path.dirname(self.path), '.glue_index'), exists_ok=True)
+        outpaths = [self._level_path(i) for i in range(self.depth)]
+        if all(os.path.exists(p + '.bgz.tbi') for p in outpaths):
+            logger.debug("Already indexed")
+            return
+
+        df = pd.read_csv(self.path, delimiter='\t', names=['chr', 'stop', 'start', 'value'])
+        check_call(f"bgzip --stdout {self.path} > {self.path}.bgz", shell=True)
+        check_call(['tabix', '-p', 'bed', self.path + '.bgz'])
+
+        downsample_factors = [self.downsample_factor ** (i + 1) for i in range(self.depth)]
+        for path, factor in zip(outpaths, downsample_factors):
+            decimated = pd.DataFrame(slf.decimate((rec for _, rec in df.iterrows()), factor),
+                                     columns=['chrom', 'start', 'stop', 'value'])
+            decimated.to_csv(path, sep='\t', index=False, header=False)
+            df = decimated
+
+            check_call(f"bgzip --stdout {path} > {path}.bgz", shell=True)
+            check_call(['tabix', '-p', 'bed', path + ".bgz"])
+
+    @staticmethod
+    def _tabix_query(path, gr: GenomeRange):
+        query = f"{gr.chrom}:{gr.start}-{gr.end}"
+        logger.debug("%s %s", path, query)
+        p = Popen(['tabix', '-f', path, query], stdout=PIPE)
+        for line in p.stdout:
+            line = line.decode('utf-8')
+            yield line.strip().split('\t')
+
+    def query(self, gr: GenomeRange, samples: int = 1000):
+
+        resolution = (gr.end - gr.start) / (samples * 2)
+        level = max((i for i in range(self.depth) if self.downsample_factor ** (i + 1) <= resolution),
+                    default=None)
+        path = self._level_path(level) + '.bgz'
+        return pd.DataFrame(self._tabix_query(path, gr), columns=['chrom', 'start', 'stop', 'value']).apply(
+            pd.to_numeric, errors='ignore')
+
+    def _level_path(self, level):
+        if level is None:
+            return self.path
+
+        a, b = os.path.split(self.path)
+        return os.path.join(a, '.glue_index', '%s.dec_%i_%i' % (b, self.downsample_factor, level))
+
+    @staticmethod
+    def decimate(intervals, step):
+        try:
+            chrom, start, stop, value = next(intervals)
+        except StopIteration:
+            return
+
+        # TODO: detect non-sorted input
+
+        # TODO: chromosome jumping
+        lo, hi = 0, step
+        current_sum = 0
+        current_max = float('-inf')
+
+        for chrom, start, stop, value in intervals:
+
+            # Start of a new interval
+            if lo is None or start >= hi:
+                if current_sum > 0:
+                    # yield chrom, lo, hi, current_sum / (hi - lo)
+                    yield chrom, lo, hi, current_max
+
+                if (stop - start) > step:
+                    # spans multiple steps
+                    yield chrom, start, stop, value
+                    lo = None
+                    current_sum = 0
+                    current_max = float('-inf')
+                else:
+                    lo = start
+                    hi = lo + step
+                    current_sum = value * (stop - start)
+                    current_max = max(current_max, value)
+
+            # Straddles an interval
+            elif stop > hi:
+                current_sum += value * (stop - start)
+                # yield chrom, lo, stop, current_sum / (stop - lo)
+                yield chrom, lo, stop, max(current_max, value)
+                lo = None
+                current_sum = 0
+                current_max = float('-inf')
+
+            # Contained in an interval
+            else:
+                current_sum += value * (stop - start)
+                current_max = max(current_max, value)
+
+        if current_sum > 0:
+            # yield chrom, lo, hi, current_sum / (hi - lo)
+            yield chrom, lo, hi, current_max / (hi - lo)
+
+
+@dataclass
+class BedPe:
+    """
+    Utility to aggregate, downsample, and query BedPe files.
+
+    Currently restricted to single-attribute datasets.
+    """
+    path: str
+    downsample_factor = 10
+    depth = 7
+
+    def index(self):
+        os.mkdirs(os.path.join(self.path.dirname(self.path), '.glue_index'), exists_ok=True)
+        outpaths = [self._level_path(i) for i in range(self.depth)]
+        if all(os.path.exists(p + '.bgz.px2') for p in outpaths):
+            logger.debug("Already indexed")
+            return
+
+        df = pd.read_csv(self.path, delimiter='\t',
+                         names=['chrom1', 'start1', 'end1', 'chrom2', 'start2', 'end2', 'value'])
+        df = df.sort_values(['chrom1', 'chrom2', 'start1', 'start2'])
+
+        assert (df.start2 >= df.end1).all()  # all loops are sorted
+        assert (df.chrom1 == df.chrom2).all()  # all loops are intra-chromosomal
+
+        check_call(f"sort -k1,1 -k4,4 -k2,2n -k5,5n {self.path} | bgzip  > {self.path}.bgz", shell=True)
+        check_call(
+            ['pairix', '-f', '-s', '1', '-d', '4', '-b', '2', '-e', '3', '-u', '5', '-v', '6', self.path + '.bgz'])
+
+        downsample_factors = [self.downsample_factor ** (i + 1) for i in range(self.depth)]
+        for path, factor in zip(outpaths, downsample_factors):
+            df = self.decimate_loops(df, factor)
+            df.to_csv(path, sep='\t', index=False, header=False)
+
+            check_call(f"bgzip --stdout {path} > {path}.bgz", shell=True)
+            logger.info("pairix", path)
+            check_call(
+                ['pairix', '-f', '-s', '1', '-d', '4', '-b', '2', '-e', '3', '-u', '5', '-v', '6', path + '.bgz'])
+
+    @staticmethod
+    def _pairix_query(path, gr: GenomeRange, verbose):
+        query = f"{gr.chrom}:{gr.start}-{gr.end}"
+        if verbose:
+            logger.info("%s %s", path, query)
+        p = Popen(['pairix', '-f', path, query], stdout=PIPE)
+        for line in p.stdout:
+            line = line.decode('utf-8')
+            yield line.strip().split('\t')
+
+    def query(self, gr: GenomeRange, target=100, level=None, verbose=True):
+        last = None
+
+        if level is not None:
+            path = self._level_path(level) + '.bgz'
+            return pd.DataFrame(self._pairix_query(path, gr, verbose),
+                                columns=['chrom1', 'start1', 'end1', 'chrom2', 'start2', 'end2', 'value']).apply(
+                pd.to_numeric, errors='ignore')
+
+        for level in range(self.depth)[::-1]:
+            path = self._level_path(level) + '.bgz'
+            df = pd.DataFrame(self._pairix_query(path, gr, verbose),
+                              columns=['chrom1', 'start1', 'end1', 'chrom2', 'start2', 'end2', 'value']).apply(
+                pd.to_numeric, errors='ignore')
+            if len(df) > target:
+                return last if last is not None else df
+            last = df
+
+        return df
+
+    def _level_path(self, level):
+        if level is None:
+            return self.path
+
+        a, b = os.path.split(self.path)
+        return os.path.join(a, '.glue_index', '%s.dec_%i_%i' % (b, self.downsample_factor, level))
+
+    @staticmethod
+    def decimate_loops(df, resolution):
+        extent = (df.end2 - df.start1)
+
+        # Remove loops with extents below the resolution
+        df = df[extent >= resolution]
+
+        # Merge loops that overlap given the resolution
+        a = ((df.end1 + df.start1) // 2) // resolution
+        b = ((df.end2 + df.start2) // 2) // resolution
+        df = df.groupby([a, b]).apply(lambda x: x.head(1).assign(value=x.value.sum()))
+
+        return df.sort_values(['chrom1', 'chrom2', 'start1', 'start2'])
+
+
+class GenomicData(Data):
+    """Base Data class for wrap Genomic files in Glue."""
+    engine_cls = None
+
+    def __init__(self, path, **kwargs):
+
+        kwargs.setdefault('label', os.path.splitext(os.path.split(path)[-1])[0])
+        # The task of making a true Glue data object entirely divorced from numpy arrays
+        # is involved. As a workaround, we give this dataset a single dummy attribute
+        # so that it has a placeholder shape, dimensionality, etc. We largely ignore
+        # this information in purpose-built data viewers, but these datasets will have
+        # strange behavior if attempting to use standard glue functionality.
+        # TODO: Fix this hack
+        kwargs['_'] = [0]
+        super().__init__(**kwargs)
+
+        self.path = path
+        self.engine = self.engine_cls(self.path)
+
+    def profile(self, chr, start, end, subset_state=None, **kwargs):
+        raise NotImplementedError
+
+
+class BedgraphData(GenomicData):
+    engine_cls = BedGraph
+
+    def profile(self, chr, start, end, subset_state=None, **kwargs):
+        result = self.engine.query(GenomeRange(f'chr{chr}', int(start), int(end)))
+        if subset_state is None:
+            return result
+
+        if isinstance(subset_state, GenomicRangeSubsetState):
+            c, s, e = subset_state.chrom, subset_state.start, subset_state.end
+            return result.loc[
+                result.chrom.eq(c) &
+                result.start.ge(s) &
+                result.stop.le(e)
+            ]
+        else:
+            # TODO: implement more general subset filtering.
+            return result.head(0)
+
+
+class BedPeData(GenomicData):
+    """Glue Data wrapper for BedGraph files."""
+    engine_cls = BedPe
+
+    def profile(self, chr, start, end, subset_state=None, target=100, **kwargs):
+        result = self.engine.query(GenomeRange(f'chr{chr}', int(start), int(end)), target=target, verbose=False)
+        if subset_state is None:
+            return result
+
+        if isinstance(subset_state, GenomicRangeSubsetState):
+            c, s, e = subset_state.chrom, subset_state.start, subset_state.end
+            return result.loc[
+                (
+                    result.chrom1.eq(c) &
+                    result.start1.ge(s) &
+                    result.end1.le(e)
+                ) |
+                (
+                    result.chrom2.eq(c) &
+                    result.start2.ge(s) &
+                    result.end2.le(e)
+                )
+            ]
+        else:
+            # TODO: implement more general subset filtering.
+            return result.head(0)

--- a/glue_genomics_viewers/genome_track/__main__.py
+++ b/glue_genomics_viewers/genome_track/__main__.py
@@ -1,0 +1,16 @@
+def demo():
+
+    from glue.core import DataCollection, Data
+    from glue.app.qt import GlueApplication
+
+    from .qt import setup
+
+    setup()
+
+    dc = DataCollection([Data(x=[1,2,3], label='data')])
+    ga = GlueApplication(dc)
+    ga.start()
+
+
+if __name__ == "__main__":
+    demo()

--- a/glue_genomics_viewers/genome_track/__main__.py
+++ b/glue_genomics_viewers/genome_track/__main__.py
@@ -1,13 +1,21 @@
+from glue.core import DataCollection
+from glue.app.qt import GlueApplication
+from ..data import BedgraphData, BedPeData
+
 def demo():
 
-    from glue.core import DataCollection, Data
-    from glue.app.qt import GlueApplication
 
     from .qt import setup
 
     setup()
 
-    dc = DataCollection([Data(x=[1,2,3], label='data')])
+    bedgraph = '/Volumes/GoogleDrive/My Drive/JAX-Test-Data/minji/MCF10A_CTCF_ChIA-PET_Rep1_coverage_ENCFF614DRY.chr3.bedgraph'
+    bedpe = '/Volumes/GoogleDrive/My Drive/JAX-Test-Data/minji/MCF10A_CTCF_ChIA-PET_Rep1_loops_ENCFF310MTX.chr3.bedpe'
+
+    dc = DataCollection([
+        BedgraphData(bedgraph),
+        BedPeData(bedpe),
+    ])
     ga = GlueApplication(dc)
     ga.start()
 

--- a/glue_genomics_viewers/genome_track/layer_artist.py
+++ b/glue_genomics_viewers/genome_track/layer_artist.py
@@ -1,0 +1,74 @@
+from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist
+from glue.utils import defer_draw
+from matplotlib.text import Text
+
+
+from .state import GenomeTrackLayerState
+
+
+class GenomeTrackLayerArtist(MatplotlibLayerArtist):
+    _layer_state_cls = GenomeTrackLayerState
+
+    def __init__(self, axes, viewer_state, layer_state=None, layer=None):
+
+        super().__init__(axes, viewer_state, layer_state=layer_state, layer=layer)
+
+        # Watch for changes in the viewer state which would require the
+        # layers to be redrawn
+        self._viewer_state.add_global_callback(self._handle_state_change)
+        self.state.add_global_callback(self._handle_state_change)
+
+    def _handle_state_change(self, force=False, **kwargs):
+        if (
+            self._viewer_state.chr is None or
+            self._viewer_state.start is None or
+            self._viewer_state.end is None or
+            self.state.layer is None
+        ):
+            return
+
+        changed = set() if force else self.pop_changed_properties()
+
+        if force or any(prop in changed for prop in ('chr', 'start', 'end')):
+            self._update_plot_data(reset=force)
+
+        if force or any(prop in changed for prop in ('alpha', 'color', 'zorder', 'visible')):
+            self._update_visual_attributes()
+
+    def _update_plot_data(self, force=False):
+        # Prepare new data
+
+        self._update_artists()
+        self._update_visual_attributes()
+        pass
+
+    @defer_draw
+    def _update_artists(self):
+
+        msg = "%s %s %s %s" % (self._viewer_state.chr, self._viewer_state.start, self._viewer_state.end, self.state.layer)
+        if not self.mpl_artists:
+            artist = Text(0.5, 0.5, msg)
+            self.mpl_artists.append(artist)
+            self.axes.add_artist(artist)
+        else:
+            self.mpl_artists[-1].set_text(msg)
+
+        self.redraw()
+
+    @defer_draw
+    def _update_visual_attributes(self):
+
+        if not self.enabled:
+            return
+
+        for mpl_artist in self.mpl_artists:
+            mpl_artist.set_visible(self.state.visible)
+            mpl_artist.set_zorder(self.state.zorder)
+
+        self.redraw()
+
+    @defer_draw
+    def update(self):
+        self.state.reset_cache()
+        self._update_plot_data(force=True)
+        self.redraw()

--- a/glue_genomics_viewers/genome_track/layer_artist.py
+++ b/glue_genomics_viewers/genome_track/layer_artist.py
@@ -1,7 +1,8 @@
+import pandas as pd
+import numpy as np
 from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist
 from glue.utils import defer_draw
-from matplotlib.text import Text
-
+from matplotlib.patches import Arc
 
 from .state import GenomeTrackLayerState
 
@@ -28,30 +29,40 @@ class GenomeTrackLayerArtist(MatplotlibLayerArtist):
             return
 
         changed = set() if force else self.pop_changed_properties()
-
-        if force or any(prop in changed for prop in ('chr', 'start', 'end')):
-            self._update_plot_data(reset=force)
+        if force or any(prop in changed for prop in ('chr', 'start', 'end', 'loop_count')):
+            self._update_plot_data(force=force)
 
         if force or any(prop in changed for prop in ('alpha', 'color', 'zorder', 'visible')):
             self._update_visual_attributes()
 
     def _update_plot_data(self, force=False):
         # Prepare new data
-
         self._update_artists()
         self._update_visual_attributes()
-        pass
+
+    @defer_draw
+    def update(self):
+        self.state.reset_cache()
+        self._update_plot_data(force=True)
+        self.redraw()
+
+
+class GenomeProfileLayerArtist(GenomeTrackLayerArtist):
 
     @defer_draw
     def _update_artists(self):
+        df: pd.DataFrame = self.state.viz_data
+        if df.empty:
+            return
 
-        msg = "%s %s %s %s" % (self._viewer_state.chr, self._viewer_state.start, self._viewer_state.end, self.state.layer)
+        x = np.vstack([df.start, df.start, df.stop, df.stop]).T.ravel()
+        y = np.vstack([df.value * 0, df.value, df.value, df.value * 0]).T.ravel()
+
         if not self.mpl_artists:
-            artist = Text(0.5, 0.5, msg)
+            artist = self.axes.fill_between(x, y)
             self.mpl_artists.append(artist)
-            self.axes.add_artist(artist)
         else:
-            self.mpl_artists[-1].set_text(msg)
+            self.mpl_artists[-1].set_verts([np.column_stack([x, y])])
 
         self.redraw()
 
@@ -64,11 +75,50 @@ class GenomeTrackLayerArtist(MatplotlibLayerArtist):
         for mpl_artist in self.mpl_artists:
             mpl_artist.set_visible(self.state.visible)
             mpl_artist.set_zorder(self.state.zorder)
+            mpl_artist.set_alpha(self.state.alpha)
+            mpl_artist.set_facecolors(self.state.color)
+
+        self.redraw()
+
+class GenomeLoopLayerArtist(GenomeTrackLayerArtist):
+
+    @defer_draw
+    def _update_artists(self):
+        df: pd.DataFrame = self.state.viz_data
+        if df.empty:
+            return
+
+        for artist in self.mpl_artists:
+            artist.remove()
+
+        self.mpl_artists = []
+        df['diameter'] = (df.start2 + df.end2) / 2. - (df.start1 + df.end1) / 2.
+
+        for _, rec in df.iterrows():
+            center = (rec.start1 + rec.end1 + rec.start2 + rec.end2) / 4.
+            height = rec.diameter
+            width = np.sqrt(min(rec.value, 10)) / 2.
+            arc = Arc(
+                (center, 0), rec.diameter,
+                height, 0, 0, 180, lw=width, alpha=0.3
+            )
+
+            self.axes.add_patch(arc)
+            self.mpl_artists.append(arc)
 
         self.redraw()
 
     @defer_draw
-    def update(self):
-        self.state.reset_cache()
-        self._update_plot_data(force=True)
+    def _update_visual_attributes(self):
+
+        if not self.enabled:
+            return
+
+        for mpl_artist in self.mpl_artists:
+            mpl_artist.set_visible(self.state.visible)
+            mpl_artist.set_zorder(self.state.zorder)
+            mpl_artist.set_alpha(self.state.alpha)
+            mpl_artist.set_facecolor(self.state.color)
+            mpl_artist.set_edgecolor(self.state.color)
+
         self.redraw()

--- a/glue_genomics_viewers/genome_track/qt/__init__.py
+++ b/glue_genomics_viewers/genome_track/qt/__init__.py
@@ -1,0 +1,6 @@
+from .data_viewer import GenomeTrackViewer  # noqa
+
+
+def setup():
+    from glue.config import qt_client
+    qt_client.add(GenomeTrackViewer)

--- a/glue_genomics_viewers/genome_track/qt/data_viewer.py
+++ b/glue_genomics_viewers/genome_track/qt/data_viewer.py
@@ -1,10 +1,13 @@
 from glue.utils import defer_draw, decorate_all_methods
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
+
+from ...data import BedgraphData
+from ...subsets import GenomicRangeSubsetState
+
 from .layer_style_editor import GenomeTrackLayerStyleEditor
 from .options_widget import GenomeTrackOptionsWidget
-from ..layer_artist import GenomeTrackLayerArtist
+from ..layer_artist import GenomeProfileLayerArtist, GenomeLoopLayerArtist
 from ..state import GenomeTrackState
-
 
 __all__ = ['GenomeTrackViewer']
 
@@ -16,10 +19,7 @@ class GenomeTrackViewer(MatplotlibDataViewer):
 
     _layer_style_widget_cls = GenomeTrackLayerStyleEditor
     _options_cls = GenomeTrackOptionsWidget
-
     _state_cls = GenomeTrackState
-    _data_artist_cls = GenomeTrackLayerArtist
-    _subset_artist_cls = GenomeTrackLayerArtist
 
     large_data_size = 2e7
 
@@ -27,3 +27,25 @@ class GenomeTrackViewer(MatplotlibDataViewer):
 
     def __init__(self, session, parent=None, state=None):
         super().__init__(session, parent=parent, state=state)
+
+    def get_data_layer_artist(self, layer=None, layer_state=None):
+        cls = GenomeProfileLayerArtist if isinstance(layer, BedgraphData) else GenomeLoopLayerArtist
+        return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
+
+    def get_subset_layer_artist(self, layer=None, layer_state=None):
+        data = layer.data if layer else None
+        cls = GenomeProfileLayerArtist if isinstance(data, BedgraphData) else GenomeLoopLayerArtist
+        return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
+
+    def apply_roi(self, roi, override_mode=None):
+
+        if len(self.layers) == 0:
+            return
+
+        x = roi.to_polygon()[0]
+        chr = self.state.chr
+        if not chr.startswith('chr'):
+            chr = 'chr' + chr
+        start, end = min(x), max(x)
+        state = GenomicRangeSubsetState(chr, start, end)
+        self.apply_subset_state(state, override_mode=override_mode)

--- a/glue_genomics_viewers/genome_track/qt/data_viewer.py
+++ b/glue_genomics_viewers/genome_track/qt/data_viewer.py
@@ -1,0 +1,29 @@
+from glue.utils import defer_draw, decorate_all_methods
+from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
+from .layer_style_editor import GenomeTrackLayerStyleEditor
+from .options_widget import GenomeTrackOptionsWidget
+from ..layer_artist import GenomeTrackLayerArtist
+from ..state import GenomeTrackState
+
+
+__all__ = ['GenomeTrackViewer']
+
+
+@decorate_all_methods(defer_draw)
+class GenomeTrackViewer(MatplotlibDataViewer):
+
+    LABEL = 'Genome Track Viewer'
+
+    _layer_style_widget_cls = GenomeTrackLayerStyleEditor
+    _options_cls = GenomeTrackOptionsWidget
+
+    _state_cls = GenomeTrackState
+    _data_artist_cls = GenomeTrackLayerArtist
+    _subset_artist_cls = GenomeTrackLayerArtist
+
+    large_data_size = 2e7
+
+    tools = ['select:xrange']
+
+    def __init__(self, session, parent=None, state=None):
+        super().__init__(session, parent=parent, state=state)

--- a/glue_genomics_viewers/genome_track/qt/layer_style_editor.py
+++ b/glue_genomics_viewers/genome_track/qt/layer_style_editor.py
@@ -1,0 +1,20 @@
+import os
+
+from qtpy import QtWidgets
+
+from echo.qt import autoconnect_callbacks_to_qt
+from glue.utils.qt import load_ui
+
+
+class GenomeTrackLayerStyleEditor(QtWidgets.QWidget):
+
+    def __init__(self, layer, parent=None):
+
+        super().__init__(parent=parent)
+
+        self.ui = load_ui('layer_style_editor.ui', self,
+                          directory=os.path.dirname(__file__))
+
+        connect_kwargs = {'alpha': dict(value_range=(0, 1))}
+
+        self._connections = autoconnect_callbacks_to_qt(layer.state, self.ui, connect_kwargs)

--- a/glue_genomics_viewers/genome_track/qt/layer_style_editor.ui
+++ b/glue_genomics_viewers/genome_track/qt/layer_style_editor.ui
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>154</width>
+    <height>96</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <property name="horizontalSpacing">
+    <number>10</number>
+   </property>
+   <property name="verticalSpacing">
+    <number>5</number>
+   </property>
+   <item row="0" column="1">
+    <widget class="QColorBox" name="color_color">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>color</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>opacity</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QSlider" name="value_alpha">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>5</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QColorBox</class>
+   <extends>QLabel</extends>
+   <header>glue.utils.qt.colors</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/glue_genomics_viewers/genome_track/qt/options_widget.py
+++ b/glue_genomics_viewers/genome_track/qt/options_widget.py
@@ -20,7 +20,8 @@ class GenomeTrackOptionsWidget(QtWidgets.QWidget):
 
         fix_tab_widget_fontsize(self.ui.tab_widget)
 
-        self._connections = autoconnect_callbacks_to_qt(viewer_state, self.ui)
+        connect_kwargs = {'loop_count': dict(value_range=(1, 200))}
+        self._connections = autoconnect_callbacks_to_qt(viewer_state, self.ui, connect_kwargs)
         self._connections_axes = autoconnect_callbacks_to_qt(viewer_state, self.ui.axes_editor.ui)
         connect_kwargs = {'alpha': dict(value_range=(0, 1))}
         self._connections_legend = autoconnect_callbacks_to_qt(viewer_state.legend, self.ui.legend_editor.ui, connect_kwargs)

--- a/glue_genomics_viewers/genome_track/qt/options_widget.py
+++ b/glue_genomics_viewers/genome_track/qt/options_widget.py
@@ -1,0 +1,49 @@
+import os
+
+from qtpy import QtWidgets
+
+from echo.qt import autoconnect_callbacks_to_qt
+from glue.utils.qt import load_ui, fix_tab_widget_fontsize
+from glue.viewers.matplotlib.state import MatplotlibDataViewerState
+
+__all__ = ['GenomeTrackOptionsWidget']
+
+
+class GenomeTrackOptionsWidget(QtWidgets.QWidget):
+
+    def __init__(self, viewer_state, session, parent=None):
+
+        super().__init__(parent=parent)
+
+        self.ui = load_ui('options_widget.ui', self,
+                          directory=os.path.dirname(__file__))
+
+        fix_tab_widget_fontsize(self.ui.tab_widget)
+
+        self._connections = autoconnect_callbacks_to_qt(viewer_state, self.ui)
+        self._connections_axes = autoconnect_callbacks_to_qt(viewer_state, self.ui.axes_editor.ui)
+        connect_kwargs = {'alpha': dict(value_range=(0, 1))}
+        self._connections_legend = autoconnect_callbacks_to_qt(viewer_state.legend, self.ui.legend_editor.ui, connect_kwargs)
+
+        self.viewer_state = viewer_state
+
+        #viewer_state.add_callback('x_att', self._update_attribute)
+
+        self.session = session
+        self.ui.axes_editor.button_apply_all.clicked.connect(self._apply_all_viewers)
+
+    def _apply_all_viewers(self):
+        for tab in self.session.application.viewers:
+            for viewer in tab:
+                if isinstance(viewer.state, MatplotlibDataViewerState):
+                    viewer.state.update_axes_settings_from(self.viewer_state)
+
+    def _update_attribute(self, *args):
+        return
+        # If at least one of the components is categorical or a date, disable log button
+        log_enabled = 'categorical' not in self.viewer_state.x_kinds
+        self.ui.bool_x_log.setEnabled(log_enabled)
+        self.ui.bool_x_log_.setEnabled(log_enabled)
+        if not log_enabled:
+            self.ui.bool_x_log.setChecked(False)
+            self.ui.bool_x_log_.setChecked(False)

--- a/glue_genomics_viewers/genome_track/qt/options_widget.ui
+++ b/glue_genomics_viewers/genome_track/qt/options_widget.ui
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Widget</class>
+ <widget class="QWidget" name="Widget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>319</width>
+    <height>418</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Genome Track Viewer</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_5">
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <property name="verticalSpacing">
+    <number>5</number>
+   </property>
+   <item row="9" column="2">
+    <widget class="QTabWidget" name="tab_widget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <property name="leftMargin">
+        <number>10</number>
+       </property>
+       <property name="topMargin">
+        <number>10</number>
+       </property>
+       <property name="rightMargin">
+        <number>10</number>
+       </property>
+       <property name="bottomMargin">
+        <number>10</number>
+       </property>
+       <property name="horizontalSpacing">
+        <number>10</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>5</number>
+       </property>
+       <item row="6" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="2">
+        <widget class="QLineEdit" name="valuetext_hist_x_max"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Range</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1" colspan="3">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Chrrom</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1" colspan="2">
+        <widget class="QComboBox" name="combosel_x_att">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="valuetext_hist_x_min"/>
+       </item>
+       <item row="4" column="1" colspan="3">
+        <widget class="QWidget" name="widget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <property name="spacing">
+           <number>5</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Limits</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <property name="leftMargin">
+        <number>10</number>
+       </property>
+       <property name="topMargin">
+        <number>10</number>
+       </property>
+       <property name="rightMargin">
+        <number>10</number>
+       </property>
+       <property name="bottomMargin">
+        <number>10</number>
+       </property>
+       <property name="horizontalSpacing">
+        <number>10</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>5</number>
+       </property>
+       <item row="1" column="1" colspan="3">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="3">
+        <widget class="QToolButton" name="bool_y_log">
+         <property name="text">
+          <string>log</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>y axis</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLineEdit" name="valuetext_y_max"/>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="valuetext_y_min"/>
+       </item>
+       <item row="2" column="2">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+      <zorder>valuetext_y_min</zorder>
+      <zorder>valuetext_y_max</zorder>
+      <zorder>bool_y_log</zorder>
+      <zorder>label_5</zorder>
+      <zorder>verticalSpacer</zorder>
+      <zorder>horizontalSpacer_2</zorder>
+     </widget>
+     <widget class="QWidget" name="tab_3">
+      <attribute name="title">
+       <string>Axes</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="leftMargin">
+        <number>5</number>
+       </property>
+       <property name="topMargin">
+        <number>5</number>
+       </property>
+       <property name="rightMargin">
+        <number>5</number>
+       </property>
+       <property name="bottomMargin">
+        <number>5</number>
+       </property>
+       <item>
+        <widget class="AxesEditorWidget" name="axes_editor" native="true"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_4">
+      <attribute name="title">
+       <string>Legend</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="leftMargin">
+        <number>5</number>
+       </property>
+       <property name="topMargin">
+        <number>5</number>
+       </property>
+       <property name="rightMargin">
+        <number>5</number>
+       </property>
+       <property name="bottomMargin">
+        <number>5</number>
+       </property>
+       <item>
+        <widget class="LegendEditorWidget" name="legend_editor" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>AxesEditorWidget</class>
+   <extends>QWidget</extends>
+   <header>glue.viewers.matplotlib.qt.axes_editor</header>
+  </customwidget>
+  <customwidget>
+   <class>LegendEditorWidget</class>
+   <extends>QWidget</extends>
+   <header>glue.viewers.matplotlib.qt.legend_editor</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/glue_genomics_viewers/genome_track/qt/options_widget.ui
+++ b/glue_genomics_viewers/genome_track/qt/options_widget.ui
@@ -71,7 +71,7 @@
         </spacer>
        </item>
        <item row="1" column="2">
-        <widget class="QLineEdit" name="valuetext_hist_x_max"/>
+        <widget class="QLineEdit" name="valuetext_end"/>
        </item>
        <item row="1" column="0">
         <widget class="QLabel" name="label">
@@ -111,7 +111,7 @@
           </font>
          </property>
          <property name="text">
-          <string>Chrrom</string>
+          <string>Chrom</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -119,10 +119,135 @@
         </widget>
        </item>
        <item row="0" column="1" colspan="2">
-        <widget class="QComboBox" name="combosel_x_att">
+        <widget class="QComboBox" name="combotext_chr">
          <property name="sizeAdjustPolicy">
           <enum>QComboBox::AdjustToMinimumContentsLength</enum>
          </property>
+         <item>
+          <property name="text">
+           <string>1</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>2</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>3</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>4</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>5</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>6</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>7</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>8</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>9</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>10</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>11</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>12</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>13</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>14</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>15</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>16</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>17</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>18</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>19</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>20</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>21</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>22</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>23</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>X</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Y</string>
+          </property>
+         </item>
         </widget>
        </item>
        <item row="3" column="1">
@@ -142,7 +267,7 @@
         </spacer>
        </item>
        <item row="1" column="1">
-        <widget class="QLineEdit" name="valuetext_hist_x_min"/>
+        <widget class="QLineEdit" name="valuetext_start"/>
        </item>
        <item row="4" column="1" colspan="3">
         <widget class="QWidget" name="widget" native="true">
@@ -169,6 +294,29 @@
            <number>0</number>
           </property>
          </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string># Loops</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1" colspan="2">
+        <widget class="QSlider" name="value_loop_count">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>200</number>
+         </property>
+         <property name="value">
+          <number>100</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
         </widget>
        </item>
       </layout>

--- a/glue_genomics_viewers/genome_track/state.py
+++ b/glue_genomics_viewers/genome_track/state.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from glue.core import BaseData, Subset
+
+from echo import delay_callback
+from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
+                                           MatplotlibLayerState,
+                                           DeferredDrawCallbackProperty as DDCProperty,
+                                           DeferredDrawSelectionCallbackProperty as DDSCProperty)
+from glue.core.state_objects import (StateAttributeLimitsHelper,
+                                     StateAttributeHistogramHelper)
+from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
+from glue.core.data_combo_helper import ComponentIDComboHelper
+from glue.utils import defer_draw, datetime64_to_mpl
+from glue.utils.decorators import avoid_circular
+
+__all__ = ['GenomeTrackState']
+
+class GenomeTrackState(MatplotlibDataViewerState):
+    """
+    Encapsulates all state for a Genome Track Viewer
+    """
+    chr = DDCProperty(docstring='The Chromosome to view')
+    start = DDCProperty(docstring="Left edge of the window")
+    end = DDCProperty(docstring="Right edge of the window")
+
+    # TODO: Include a configurable list of tracks. For now hardcode
+
+
+class GenomeTrackLayerState(MatplotlibLayerState):
+
+    _cache = None
+
+    def reset_cache(self, *args):
+        self._cache = None
+
+    @property
+    def viewer_state(self):
+        return self._viewer_state
+
+    @viewer_state.setter
+    def viewer_state(self, viewer_state):
+        self._viewer_state = viewer_state
+
+    def recalculate_plot_data(self):
+
+        if isinstance(self.layer, Subset):
+            data = self.layer.data
+            subset_state = self.layer.subset_state
+        else:
+            data = self.layer
+            subset_state = None

--- a/glue_genomics_viewers/genome_track/state.py
+++ b/glue_genomics_viewers/genome_track/state.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 from glue.core import BaseData, Subset
 
@@ -13,9 +14,15 @@ from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataExceptio
 from glue.core.data_combo_helper import ComponentIDComboHelper
 from glue.utils import defer_draw, datetime64_to_mpl
 from glue.utils.decorators import avoid_circular
+from glue.utils import defer_draw, decorate_all_methods
+
+from ..subsets import GenomicRangeSubsetState
+from ..data import BedPeData
 
 __all__ = ['GenomeTrackState']
 
+
+@decorate_all_methods(defer_draw)
 class GenomeTrackState(MatplotlibDataViewerState):
     """
     Encapsulates all state for a Genome Track Viewer
@@ -23,26 +30,72 @@ class GenomeTrackState(MatplotlibDataViewerState):
     chr = DDCProperty(docstring='The Chromosome to view')
     start = DDCProperty(docstring="Left edge of the window")
     end = DDCProperty(docstring="Right edge of the window")
+    loop_count = DDCProperty(docstring="Number of loops to display")
 
     # TODO: Include a configurable list of tracks. For now hardcode
+
+    def __init__(self, **kwargs):
+        super().__init__()
+
+        self.add_callback('start', self.update_view_to_range)
+        self.add_callback('end', self.update_view_to_range)
+
+        self.add_callback('x_min', self.update_range_to_view)
+        self.add_callback('x_max', self.update_range_to_view)
+
+        self.chr = '3'
+        self.start = 100_000
+        self.end = 500_000
+        self.loop_count = 100
+
+    @avoid_circular
+    def update_view_to_range(self, *args):
+        with delay_callback(self, 'x_min', 'x_max'):
+            self.x_min = self.start
+            self.x_max = self.end
+
+    @avoid_circular
+    def update_range_to_view(self, *args):
+        with delay_callback(self, 'start', 'end'):
+            self.start = self.x_min
+            self.end = self.x_max
+
+    def expand_y_limits(self, y_min, y_max):
+        if y_min is None or y_max is None or not np.isfinite(y_min) or not np.isfinite(y_max):
+            return
+
+        if self.y_min is None:
+            self.y_min = y_min
+        else:
+            self.y_min = min(self.y_min, y_min)
+
+        if self.y_max is None:
+            self.y_max = y_max
+        else:
+            self.y_max = max(self.y_min or -np.inf, y_max)
 
 
 class GenomeTrackLayerState(MatplotlibLayerState):
 
-    _cache = None
+    _cache = None, None
 
     def reset_cache(self, *args):
-        self._cache = None
+        self._cache = None, None
 
     @property
-    def viewer_state(self):
+    def viewer_state(self) -> GenomeTrackState:
         return self._viewer_state
 
     @viewer_state.setter
-    def viewer_state(self, viewer_state):
+    def viewer_state(self, viewer_state: GenomeTrackState):
         self._viewer_state = viewer_state
 
-    def recalculate_plot_data(self):
+    @property
+    def viz_data(self) -> pd.DataFrame:
+        key = self.viewer_state.chr, int(max(self.viewer_state.start, 0)), int(max(self.viewer_state.end, 0)), self.viewer_state.loop_count
+        if key == self._cache[0]:
+            return self._cache[1]
+        chr, start, end, loop_count = key
 
         if isinstance(self.layer, Subset):
             data = self.layer.data
@@ -50,3 +103,13 @@ class GenomeTrackLayerState(MatplotlibLayerState):
         else:
             data = self.layer
             subset_state = None
+
+        if isinstance(data, BedPeData):
+            df = data.profile(chr, start, end, target=loop_count, subset_state=subset_state)
+            self.viewer_state.expand_y_limits(0, end - start)
+        else:
+            df = data.profile(chr, start, end, subset_state=subset_state)
+            self.viewer_state.expand_y_limits(df.value.min(), df.value.max(), subset_state=subset_state)
+
+        self._cache = key, df
+        return df

--- a/glue_genomics_viewers/subsets.py
+++ b/glue_genomics_viewers/subsets.py
@@ -1,0 +1,17 @@
+from glue.core.state import SubsetState
+
+
+class GenomicRangeSubsetState(SubsetState):
+    """A subset state defined by a (chrom, start, end) triple.
+
+    The subset is inclusive of the endpoints.
+    """
+    def __init__(self, chrom, start, end):
+        self.chrom = chrom
+        self.start = start
+        self.end = end
+
+    def copy(self):
+        return GenomicRangeSubsetState(self.chrom, self.start, self.end)
+
+    # Todo: attempt to define to_mask and/or to_index_list? These can be expensive...

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     glue
+    coolbox
 
 [options.entry_points]
 glue.plugins =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,56 @@
+[metadata]
+name = glue_genomics_viewers
+url = http://glueviz.org
+author = Jonathan Foster
+author_email = glueviz@gmail.com
+classifiers =
+    Intended Audience :: Science/Research
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Scientific/Engineering :: Visualization
+    License :: OSI Approved :: BSD License
+description = Supplemental Genomics Data Viewers for Glue
+
+[options]
+zip_safe = False
+packages = find:
+python_requires = >=3.7
+setup_requires = setuptools_scm
+install_requires =
+    glue
+
+[options.entry_points]
+glue.plugins =
+    genome_track_viewer = genome_track.qt:setup
+
+[options.extras_require]
+qt =
+    PyQt5>=5.9
+test =
+    pytest
+    pytest-cov
+    pytest-faulthandler
+    objgraph
+
+[options.package_data]
+* = *.png, *.ui, *.glu, *.hdf5, *.fits, *.xlsx, *.txt, *.csv, *.svg, *.vot
+
+[flake8]
+ignore = E501,E731,F841,E127,E741,E402,W504,W605
+
+[tool:pytest]
+addopts=-p no:logging
+flake8-ignore = E501,E731,F841,E127,E741,E402,W504,W605
+filterwarnings =
+    ignore::PendingDeprecationWarning:xlrd
+    ignore:Session._key_changed is deprecated
+    ignore:zmq.* is deprecated
+    ignore:can't be aliased because it is another magic command
+    ignore:DragAndDropTerminal._style_sheet_changed is deprecated
+    ignore:::ipykernel
+    ignore:Accessing zmq Socket attribute
+    ignore:'U' mode is deprecated:DeprecationWarning:PyQt5

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
This PR adds prototype data loaders + viewers for BedPe and BedGraph files. The main features include:

* Utilities to downsample and aggregate bedgraph/bedpe files, which allow viz-friendly querying of data by genomic range on the fly
* A glue Data wrapper for each of these utilities
* A genomics viewer that can render profiles and/or loops (currently each "track" is a separate viewer window, not a vertically-aligned stack as is more standard)
* The ability to define subsets based on a single Genomic Range.

You can demo this using `python -m glue_genomics_viewers.genome_track` (although you may need to update the paths of the data in that module)

There's lot's to clean up and improve up on here, including:

1) The data objects currently masquerade as "standard" glue datasets with a dummy component, and rely on the genomics data viewer to invoke special data query methods. 
2) These datasets are incompatible with all other data viewers, but the UI doesn't hide unsupported viewers. 
3) More complex subsets (e.g. boolean combinations) are not supported
4) Multiple genome track windows are not vertically aligned
5) The pre-aggregators must be manually invoked prior to using Glue, and they are currently very slow.
 