### PR TITLE
Show multiple datasets as different parallel tracks

### DIFF
--- a/glue_genomics_viewers/data.py
+++ b/glue_genomics_viewers/data.py
@@ -83,10 +83,11 @@ class BedGraph:
             pd.to_numeric, errors='ignore')
 
     def _level_path(self, level):
-        if level is None:
-            return self.path
-
         a, b = os.path.split(self.path)
+
+        if level is None:
+            return os.path.join(a, '.glue_index', b)
+
         return os.path.join(a, '.glue_index', '%s.dec_%i_%i' % (b, self.downsample_factor, level))
 
     @staticmethod
@@ -212,10 +213,11 @@ class BedPe:
         return df
 
     def _level_path(self, level):
-        if level is None:
-            return self.path
 
         a, b = os.path.split(self.path)
+        if level is None:
+            return os.path.join(a, '.glue_index', b)
+
         return os.path.join(a, '.glue_index', '%s.dec_%i_%i' % (b, self.downsample_factor, level))
 
     @staticmethod

--- a/glue_genomics_viewers/genome_track/qt/data_viewer.py
+++ b/glue_genomics_viewers/genome_track/qt/data_viewer.py
@@ -1,3 +1,5 @@
+from matplotlib.axes._axes import _TransformedBoundsLocator
+import numpy as np
 from glue.utils import defer_draw, decorate_all_methods
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
 
@@ -27,15 +29,22 @@ class GenomeTrackViewer(MatplotlibDataViewer):
 
     def __init__(self, session, parent=None, state=None):
         super().__init__(session, parent=parent, state=state)
+        self._layer_artist_container.on_changed(self.reflow_tracks)
 
     def get_data_layer_artist(self, layer=None, layer_state=None):
         cls = GenomeProfileLayerArtist if isinstance(layer, BedgraphData) else GenomeLoopLayerArtist
-        return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
+        result = self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
+        result.state.add_callback('zorder', self.reflow_tracks)
+        result.state.add_callback('visible', self.reflow_tracks)
+        return result
 
     def get_subset_layer_artist(self, layer=None, layer_state=None):
         data = layer.data if layer else None
         cls = GenomeProfileLayerArtist if isinstance(data, BedgraphData) else GenomeLoopLayerArtist
-        return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
+        result = self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
+        result.state.add_callback('zorder', self.reflow_tracks)
+        result.state.add_callback('visible', self.reflow_tracks)
+        return result
 
     def apply_roi(self, roi, override_mode=None):
 
@@ -49,3 +58,19 @@ class GenomeTrackViewer(MatplotlibDataViewer):
         start, end = min(x), max(x)
         state = GenomicRangeSubsetState(chr, start, end)
         self.apply_subset_state(state, override_mode=override_mode)
+
+    def reflow_tracks(self, *args):
+        """
+        Reorder each track top->bottom sorted by zorder, removing any gaps of non-visible tracks.
+        """
+        axes = {}
+        for artist in self._layer_artist_container.artists:
+            if not artist.state.visible:
+                continue
+            axes[artist.track_axes] = min(axes.get(artist.track_axes, np.inf), artist.zorder)
+
+        track_cnt = len(axes)
+        height = 0.9 / track_cnt
+        for i, ax in enumerate(sorted(axes, key=axes.get)):
+            bounds = _TransformedBoundsLocator([0, i / track_cnt, 1, height], ax.axes.transAxes)
+            ax.set_axes_locator(bounds)


### PR DESCRIPTION
This modifies the Genomics Viewer to setup parallel tracks for each data layer in the viewer. The order of layers matches the presentation in the left-panel layer view. 

![image](https://user-images.githubusercontent.com/796752/133552078-80bf0669-683c-4a05-86a1-61750d12eb2e.png)
