### PR TITLE
Genomic Track Improvements

### DIFF
--- a/glue_genomics_viewers/genome_track/__main__.py
+++ b/glue_genomics_viewers/genome_track/__main__.py
@@ -1,9 +1,12 @@
+import os
+
 from glue.core import DataCollection, Data
 from glue.app.qt import GlueApplication
 from ..data import BedgraphData, BedPeData
 import numpy as np
 from glue_genomics_viewers.heatmap.data_viewer import HeatmapViewer
 from glue.viewers.table.qt import TableViewer
+from glue_genomics_viewers.genome_track.qt import GenomeTrackViewer
 from glue_genomics_viewers.heatmap.heatmap_coords import HeatmapCoords
 
 import pandas as pd
@@ -30,16 +33,17 @@ def demo():
 
     setup()
 
-    bedgraph = '/Users/jfoster/Desktop/JAX/TestData/minji/MCF10A_CTCF_ChIA-PET_Rep1_coverage_ENCFF614DRY.chr3.bedgraph'
-    bedpe = '/Users/jfoster/Desktop/JAX/TestData/minji/MCF10A_CTCF_ChIA-PET_Rep1_loops_ENCFF310MTX.chr3.bedpe'
+    base_dir = os.environ.get('GLUEGENES_DEMO_DIR', '/Users/jfoster/Desktop/JAX/TestData')
+    bedgraph = f'{base_dir}/minji/MCF10A_CTCF_ChIA-PET_Rep1_coverage_ENCFF614DRY.chr3.bedgraph'
+    bedpe = f'{base_dir}/minji/MCF10A_CTCF_ChIA-PET_Rep1_loops_ENCFF310MTX.chr3.bedpe'
     #bedgraph = '/Users/jfoster/Desktop/sep17-demo-data/mm10_coverage_M.bedgraph'
-    tadfile = '/Users/jfoster/Desktop/JAX/TestData/atac_rna/Test_TAD.mm10Lifted.bed'
-    tad_data = pd.read_csv(tadfile,names=['chr','start','end','num','name'],sep='\t')
+    tadfile = f'{base_dir}/atac_rna/Test_TAD.mm10Lifted.bed'
+    #tad_data = pd.read_csv(tadfile,names=['chr','start','end','num','name'],sep='\t')
     
-    enhancer_file = '/Users/jfoster/Desktop/JAX/TestData/minji_loops/Enhancers_and_Promoters.bed'
-    enhancer_data = pd.read_csv(enhancer_file,names=['chr','start','end','state'],usecols=['chr','start','end','state'],sep='\t')
-    enhancer_data = enhancer_data[enhancer_data['chr']=='chr3']
-    enhancer_data['major_states'] =  enhancer_data.apply(classify,axis=1)
+    enhancer_file = f'{base_dir}/minji_loops/Enhancers_and_Promoters.bed'
+    #enhancer_data = pd.read_csv(enhancer_file,names=['chr','start','end','state'],usecols=['chr','start','end','state'],sep='\t')
+    #enhancer_data = enhancer_data[enhancer_data['chr']=='chr3']
+    #enhancer_data['major_states'] =  enhancer_data.apply(classify,axis=1)
     #yo = BedgraphData(bedgraph)
     #yo.engine.index()
     
@@ -47,7 +51,7 @@ def demo():
     #yo.engine.index()
 
     
-    df_counts = pd.read_csv('/Users/jfoster/Desktop/JAX/TestData/three_bears/three_bears_liver_rnaseq_matrix_counts.txt', sep='\t')
+    df_counts = pd.read_csv(f'{base_dir}/three_bears/three_bears_liver_rnaseq_matrix_counts.txt', sep='\t')
     counts_data = np.array(df_counts)
     
     gene_numbers = [int(x[7:]) for x in df_counts.index.values]  # Not general
@@ -65,7 +69,7 @@ def demo():
              exp_ids=experiment_array,
              label='gene_expression',
               coords=HeatmapCoords(n_dim=2, x_axis_ticks=exp_labels, y_axis_ticks=gene_labels, labels=['Experiment ID','Gene ID']))
-    df_metadata = pd.read_csv('/Users/jfoster/Desktop/JAX/TestData/three_bears/three_bears_liver_rnaseq_matrix_metadata.txt', sep='\t')#.set_index(metadata_index)
+    df_metadata = pd.read_csv(f'{base_dir}/three_bears/three_bears_liver_rnaseq_matrix_metadata.txt', sep='\t')#.set_index(metadata_index)
     df_metadata.columns = df_metadata.columns.str.lower()  # For consistency
     
     df_metadata['orsam_id'] = [int(x[5:]) for x in df_metadata['barcode']]
@@ -73,7 +77,7 @@ def demo():
     d2 = df_to_data(df_metadata,label='rnaseq_metadata')
 
     
-    df_gene_table = pd.read_csv('/Users/jfoster/Desktop/JAX/TestData/three_bears/three_bears_liver_rnaseq_geneInfo.txt', sep='\t').set_index('gene.id')
+    df_gene_table = pd.read_csv(f'{base_dir}/three_bears/three_bears_liver_rnaseq_geneInfo.txt', sep='\t').set_index('gene.id')
     df_gene_table['gene_ids'] = [int(x[7:]) for x in df_gene_table.index.values]
     df_gene_table['chr'] = 'chr'+df_gene_table['chr'].astype(str)
     df_gene_table['start'] = df_gene_table['start']*100_000
@@ -89,16 +93,22 @@ def demo():
         #BedgraphData(bedgraph,label='Moredata'),
         BedPeData(bedpe,label='CTCF_ChIA-PET_loops'),
     ])
-    dc['Chromatin State'] = enhancer_data
+    #dc['Chromatin State'] = enhancer_data
     ga = GlueApplication(dc)
     dc[0].join_on_key(dc[1],'exp_ids','orsam_id')
     #dc[0].join_on_key(dc[2],'gene_ids','gene_ids')
 
-    scatter = ga.new_data_viewer(HeatmapViewer)
-    scatter.add_data(d1)
+    #scatter = ga.new_data_viewer(HeatmapViewer)
+    #scatter.add_data(d1)
     
-    metadata = ga.new_data_viewer(TableViewer)
-    metadata.add_data(d2)
+    #metadata = ga.new_data_viewer(TableViewer)
+    #metadata.add_data(d2)
+
+    t = ga.new_data_viewer(GenomeTrackViewer)
+    t.add_data(dc[2])
+    t.state.chr = '3'
+    t.state.start = 3828283
+    t.state.end = 3831057
 
     ga.start()
 

--- a/glue_genomics_viewers/genome_track/qt/data_viewer.py
+++ b/glue_genomics_viewers/genome_track/qt/data_viewer.py
@@ -1,21 +1,29 @@
+import logging
+import os
+
+from echo import delay_callback
 from matplotlib.axes._base import _TransformedBoundsLocator
 import numpy as np
-from glue.utils import defer_draw, decorate_all_methods
+from glue.core import Subset
+from glue.utils import nonpartial, defer_draw, decorate_all_methods
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
+import coolbox.api as cb
 
+from qtpy import QtWidgets
 from ...data import BedgraphData
 from ...subsets import GenomicRangeSubsetState
 
 from .layer_style_editor import GenomeTrackLayerStyleEditor
 from .options_widget import GenomeTrackOptionsWidget
-from ..layer_artist import GenomeProfileLayerArtist, GenomeLoopLayerArtist
+from ..layer_artist import GenomeProfileLayerArtist, GenomeLoopLayerArtist, GenomeTrackLayerArtist
 from ..state import GenomeTrackState
+from ..utils import PanTrackerMixin
 
 __all__ = ['GenomeTrackViewer']
 
 
 @decorate_all_methods(defer_draw)
-class GenomeTrackViewer(MatplotlibDataViewer):
+class GenomeTrackViewer(MatplotlibDataViewer, PanTrackerMixin):
 
     LABEL = 'Genome Track Viewer'
 
@@ -30,6 +38,36 @@ class GenomeTrackViewer(MatplotlibDataViewer):
     def __init__(self, session, parent=None, state=None):
         super().__init__(session, parent=parent, state=state)
         self._layer_artist_container.on_changed(self.reflow_tracks)
+
+        self.init_pan_tracking(self.axes)
+        self._setup_annotation_track()
+
+        self.state.add_callback('chr', self._redraw_annotation)
+        self.state.add_callback('start', self._redraw_annotation)
+        self.state.add_callback('end', self._redraw_annotation)
+        self.state.add_callback('show_annotations', self.reflow_tracks)
+        self._setup_zoom_to_layer_action()
+
+    def _setup_zoom_to_layer_action(self):
+        layer_artist_view = self._view.layer_list
+        act = QtWidgets.QAction('Zoom to Layer', layer_artist_view)
+        act.triggered.connect(nonpartial(self._zoom_to_layer))
+        layer_artist_view.addAction(act)
+
+    def _zoom_to_layer(self):
+        layer = self._view.layer_list.current_artist().layer
+
+        if not isinstance(layer, Subset):
+            return
+        try:
+            chr, start, end = layer.subset_state.extent()
+        except AttributeError:
+            return
+
+        with delay_callback(self.state, 'chr', 'start', 'end'):
+            self.state.chr = chr.lstrip('chr')
+            self.state.start = start
+            self.state.end = end
 
     def get_data_layer_artist(self, layer=None, layer_state=None):
         cls = GenomeProfileLayerArtist if isinstance(layer, BedgraphData) else GenomeLoopLayerArtist
@@ -46,8 +84,10 @@ class GenomeTrackViewer(MatplotlibDataViewer):
         result.state.add_callback('visible', self.reflow_tracks)
         return result
 
-    def apply_roi(self, roi, override_mode=None):
+    def on_pan_end(self):
+        self.reflow_tracks()
 
+    def apply_roi(self, roi, override_mode=None):
         if len(self.layers) == 0:
             return
 
@@ -59,6 +99,39 @@ class GenomeTrackViewer(MatplotlibDataViewer):
         state = GenomicRangeSubsetState(chr, start, end)
         self.apply_subset_state(state, override_mode=override_mode)
 
+    def _setup_annotation_track(self):
+        self.annotations_ax = GenomeTrackLayerArtist._setup_track_axes(
+            self.axes, 'annotations', self.state)
+        self.annotation = cb.BED(
+            os.environ.get('GLUEGENES_GENE_FILE', 'gencodeVM23_bed12.bed'),
+            num_rows=None,
+            gene_style='simple',
+            bed_type='bed12',
+            fontsize=8,
+        )
+        self.annotations_ax.get_yaxis().set_visible(False)
+        self.annotations_ax.spines['left'].set_visible(False)
+
+    def _redraw_annotation(self, *args):
+        if self.panning:
+            return
+        self.annotations_ax.set_visible(self.state.show_annotations)
+
+        if not self.state.show_annotations:
+            self.axes.figure.canvas.draw_idle()
+            return
+
+        self.annotations_ax.clear()
+        start = max(int(self.state.start), 0)
+        end = max(int(self.state.end), 0)
+        start, end = min(start, end), max(start, end)
+        self.annotation.is_draw_labels = True
+        self.annotation.plot(
+            self.annotations_ax,
+            cb.GenomeRange(f"{self.state.chr}:{start}-{end}")
+        )
+        self.axes.figure.canvas.draw_idle()
+
     def reflow_tracks(self, *args):
         """
         Reorder each track top->bottom sorted by zorder, removing any gaps of non-visible tracks.
@@ -69,8 +142,14 @@ class GenomeTrackViewer(MatplotlibDataViewer):
                 continue
             axes[artist.track_axes] = min(axes.get(artist.track_axes, np.inf), artist.zorder)
 
+        axes = list(sorted(axes, key=axes.get))
+        if self.state.show_annotations:
+            axes = [self.annotations_ax] + axes
+
         track_cnt = len(axes)
         height = 0.9 / track_cnt
-        for i, ax in enumerate(sorted(axes, key=axes.get)):
+        for i, ax in enumerate(axes):
             bounds = _TransformedBoundsLocator([0, i / track_cnt, 1, height], ax.axes.transAxes)
             ax.set_axes_locator(bounds)
+
+        self._redraw_annotation()

--- a/glue_genomics_viewers/genome_track/qt/options_widget.ui
+++ b/glue_genomics_viewers/genome_track/qt/options_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>319</width>
+    <width>369</width>
     <height>418</height>
    </rect>
   </property>
@@ -57,7 +57,39 @@
        <property name="verticalSpacing">
         <number>5</number>
        </property>
-       <item row="6" column="0">
+       <item row="4" column="1">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="1" colspan="2">
+        <widget class="QSlider" name="value_loop_count">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>200</number>
+         </property>
+         <property name="value">
+          <number>100</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -69,9 +101,6 @@
           </size>
          </property>
         </spacer>
-       </item>
-       <item row="1" column="2">
-        <widget class="QLineEdit" name="valuetext_end"/>
        </item>
        <item row="1" column="0">
         <widget class="QLabel" name="label">
@@ -89,18 +118,12 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="1" colspan="3">
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+       <item row="2" column="0" alignment="Qt::AlignRight">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string># Loops</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>5</height>
-          </size>
-         </property>
-        </spacer>
+        </widget>
        </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label_3">
@@ -116,6 +139,56 @@
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QCheckBox" name="bool_show_annotations">
+         <property name="text">
+          <string>Show Genes</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QLineEdit" name="valuetext_end"/>
+       </item>
+       <item row="7" column="1" colspan="3">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="5" column="1" colspan="3">
+        <widget class="QWidget" name="widget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <property name="spacing">
+           <number>5</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+         </layout>
         </widget>
        </item>
        <item row="0" column="1" colspan="2">
@@ -250,74 +323,8 @@
          </item>
         </widget>
        </item>
-       <item row="3" column="1">
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>5</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
        <item row="1" column="1">
         <widget class="QLineEdit" name="valuetext_start"/>
-       </item>
-       <item row="4" column="1" colspan="3">
-        <widget class="QWidget" name="widget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <property name="spacing">
-           <number>5</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string># Loops</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1" colspan="2">
-        <widget class="QSlider" name="value_loop_count">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>200</number>
-         </property>
-         <property name="value">
-          <number>100</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
        </item>
       </layout>
      </widget>
@@ -470,4 +477,7 @@
  </customwidgets>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="loop_filter_mode"/>
+ </buttongroups>
 </ui>

--- a/glue_genomics_viewers/genome_track/state.py
+++ b/glue_genomics_viewers/genome_track/state.py
@@ -24,6 +24,7 @@ class GenomeTrackState(MatplotlibDataViewerState):
     start = DDCProperty(docstring="Left edge of the window")
     end = DDCProperty(docstring="Right edge of the window")
     loop_count = DDCProperty(docstring="Number of loops to display")
+    show_annotations = DDCProperty(default=True, docstring="Show Annotations?")
 
     def __init__(self, **kwargs):
         super().__init__()
@@ -53,6 +54,7 @@ class GenomeTrackState(MatplotlibDataViewerState):
             self.start = self.x_min
             self.end = self.x_max
 
+
 class GenomeTrackLayerState(MatplotlibLayerState):
 
     _cache = None, None
@@ -77,7 +79,6 @@ class GenomeTrackLayerState(MatplotlibLayerState):
 
         
         if isinstance(self.layer, Subset):
-            #print(f"In isinstance: {self.layer.subset_state}")
             data = self.layer.data
             subset_state = self.layer.subset_state
             if not isinstance(subset_state, GenomicRangeSubsetState):
@@ -90,9 +91,8 @@ class GenomeTrackLayerState(MatplotlibLayerState):
         else:
             data = self.layer
             subset_state = None
-        #print(f'final subset_state = {subset_state}')
         if isinstance(data, BedPeData):
-            df = data.profile(chr, start, end, target=loop_count, subset_state=subset_state)
+            df = data.profile(chr, start, end, target=loop_count, required_endpoints='both', subset_state=subset_state)
         else:
             df = data.profile(chr, start, end, subset_state=subset_state)
 

--- a/glue_genomics_viewers/genome_track/utils.py
+++ b/glue_genomics_viewers/genome_track/utils.py
@@ -1,0 +1,102 @@
+import math
+from matplotlib.ticker import ScalarFormatter
+
+
+class PanTrackerMixin:
+    """
+    Helper class that tracks drag events when using the pan/zoom mode in the matplotlib toolbar.
+
+    The `panning` holds whether the user is currently panning+zooming, and the `on_pan_end` method
+    (a no-op that can be overloaded) is called immediately after a pan+zoom ends.
+
+    This can be used to skip expensive operations during pan+zoom, to keep that interaction fluid.
+    """
+    def init_pan_tracking(self, axes):
+        self.panning = False
+        self.__axes = axes
+        axes.figure.canvas.mpl_connect('button_press_event', self._on_press)
+        axes.figure.canvas.mpl_connect('button_release_event', self._on_release)
+
+    def _on_press(self, event=None, force=False):
+        try:
+            mode = self.__axes.figure.canvas.toolbar.mode
+        except AttributeError:  # pragma: nocover
+            return
+        self.panning = mode == 'pan/zoom'
+
+    def _on_release(self, event=None):
+        was_panning = self.panning
+        self.panning = False
+
+        if was_panning:
+            self.on_pan_end()
+
+    def on_pan_end(self):
+        pass
+
+
+class GenomeTrackFormatter(ScalarFormatter):
+    """Format numbers in kdb/Mbp, instead of scientific notation"""
+    chrom = ''
+
+    def format_data(self, value):
+        e = math.floor(math.log10(abs(value)))
+        s = round(value / 10**e, 10)
+        exponent = self._format_maybe_minus_and_locale("%d", e)
+        if e == 3:
+            suffix = ' kbp'
+        elif e == 4:
+            suffix = ' kbp'
+            s *= 10
+        elif e == 5:
+            suffix = ' kbp'
+            s *= 100
+        elif e == 6:
+            suffix = ' Mbp'
+        elif e == 7:
+            suffix = ' Mbp'
+            s *= 10
+        elif e == 8:
+            suffix = ' Mbp'
+            s *= 100
+        else:
+            suffix = f'e{exponent}'
+
+        significand = self._format_maybe_minus_and_locale(
+            "%d" if s % 1 == 0 else "%1.10f", s)
+        if e == 0:
+            return significand
+        return f"{significand}{suffix}"
+
+    def get_offset(self):
+        if len(self.locs) == 0:
+            return ''
+
+        s = ''
+        if self.orderOfMagnitude or self.offset:
+            offsetStr = ''
+            sciNotStr = ''
+            if self.offset:
+                print(self.offset)
+                offsetStr = self.format_data(self.offset)
+                if self.offset > 0:
+                    offsetStr = '+' + offsetStr
+            if self.orderOfMagnitude:
+                if self.orderOfMagnitude == 3:
+                    sciNotStr = ' kbp'
+                elif self.orderOfMagnitude == 4:
+                    sciNotStr = '10 kbp'
+                elif self.orderOfMagnitude == 5:
+                    sciNotStr = '100 kbp'
+                elif self.orderOfMagnitude == 6:
+                    sciNotStr = ' Mbp'
+                elif self.orderOfMagnitude == 7:
+                    sciNotStr = '10 Mbp'
+                elif self.orderOfMagnitude == 8:
+                    sciNotStr = '100 Mbp'
+                else:
+                    sciNotStr = f'1e{self.orderOfMagnitude}'
+            s = ''.join((sciNotStr, offsetStr))
+
+        return f'{self.chrom}:{self.fix_minus(s)}'
+

--- a/glue_genomics_viewers/subsets.py
+++ b/glue_genomics_viewers/subsets.py
@@ -21,7 +21,10 @@ class GenomicMulitRangeSubsetState(SubsetState):
             self.chroms.append(subset.chrom)
             self.starts.append(subset.start)
             self.ends.append(subset.end)
-            
+
+    def extent(self):
+        return self.chroms[0], min(self.starts), max(self.ends)
+
     def copy(self):
         return GenomicMulitRangeSubsetState(self._subsets)
             
@@ -58,6 +61,9 @@ class GenomicRangeSubsetState(SubsetState):
         self.chrom = chrom
         self.start = start
         self.end = end
+
+    def extent(self):
+        return self.chrom, self.start, self.end
 
     def copy(self):
         return GenomicRangeSubsetState(self.chrom, self.start, self.end)


### PR DESCRIPTION
This PR adds several improvements to the Genomics Track Viewer:

The X axis is formatted in kb/MB, and displays the chromosome

![image](https://user-images.githubusercontent.com/796752/138530088-2b5d6c20-4486-4929-aefd-6bc578254754.png)

The viewer includes an option to show a coolbox-rendering of the `gencodeVM23` dataset (as discussed, this is not loaded as a glue data object, but rather assumed to exist in either the current directory as `gencodeVM23_bed12.bed` or the `GLUEGENES_GENE_FILE` environment variable. This dataset is also lightly massaged to conform to the [bed12 format](https://genome.ucsc.edu/FAQ/FAQformat.html), which coolbox requires. A version of this file is in the google drive). 

![image](https://user-images.githubusercontent.com/796752/138530446-cf3c9c97-cf65-4423-a5c4-02adeddf9af1.png)

There's an option to right click on a subset in the layer widget, and select "zoom to layer" to update the viewport to the subset's extent
![image](https://user-images.githubusercontent.com/796752/138530603-2a951dc0-17b3-4678-a95d-826336d28427.png)

Panning+zooming pauses recalculation of the track data layers, to keep that action reasonably smooth
