### PR TITLE
Avoid parix/tabix CLIs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,9 @@ setup_requires = setuptools_scm
 install_requires =
     glue-core@git+https://github.com/gluesolutions/glue.git
     matplotlib >= 3.4
+    coolbox
+    pypairix
+    pytabix
     seaborn
     ncls
     pandas


### PR DESCRIPTION
This removes direct usage of parix/tabix, in favor of their python equivalents, in viz-time code.

Note there is still a dependence on the CLIs for the downsampling/indexing utilities, since we aren't currently prioritizing reusability of this functionality.