### PR TITLE
Zoom to data bounds on first layer load

### DIFF
--- a/glue_genomics_viewers/data.py
+++ b/glue_genomics_viewers/data.py
@@ -85,6 +85,18 @@ class BedGraph:
         return pd.DataFrame(self._tabix_query(path, gr), columns=['chrom', 'start', 'stop', 'value']).apply(
             pd.to_numeric, errors='ignore')
 
+    def get_chrom_bounds(self):
+        df = self.downsampled_dataframe(self.depth - 1)
+        return [
+            (c, lo, hi)
+            for c, (lo, hi) in
+            df.groupby('chrom').apply(lambda grp: (grp.start.min(), grp.stop.max())).items()
+        ]
+
+    def downsampled_dataframe(self, level):
+        path = self._level_path(level) + '.bgz'
+        return pd.read_csv(path, compression='gzip', delimiter='\t', names=['chrom', 'stop', 'start', 'value'])
+
     def _level_path(self, level):
         a, b = os.path.split(self.path)
 
@@ -221,6 +233,21 @@ class BedPe:
 
         return df
 
+    def get_chrom_bounds(self):
+        df = self.downsampled_dataframe(self.depth - 1)
+        return [
+            (c, lo, hi)
+            for c, (lo, hi) in
+            df.groupby('chrom1').apply(lambda grp: (grp.start1.min(), grp.end2.max())).items()
+        ]
+
+    def downsampled_dataframe(self, level):
+        path = self._level_path(level) + '.bgz'
+        return pd.read_csv(
+            path, compression='gzip', delimiter='\t',
+            names=['chrom1', 'start1', 'end1', 'chrom2', 'start2', 'end2', 'value']
+        )
+
     def _level_path(self, level):
 
         a, b = os.path.split(self.path)
@@ -265,6 +292,10 @@ class GenomicData(Data):
 
     def profile(self, chr, start, end, subset_state=None, **kwargs):
         raise NotImplementedError
+
+    def get_chrom_bounds(self):
+        """Return a list of (chr, start, end) describing the range of data along each chromosome"""
+        return self.engine.get_chrom_bounds()
 
 
 class BedgraphData(GenomicData):

--- a/glue_genomics_viewers/genome_track/qt/data_viewer.py
+++ b/glue_genomics_viewers/genome_track/qt/data_viewer.py
@@ -69,11 +69,27 @@ class GenomeTrackViewer(MatplotlibDataViewer, PanTrackerMixin):
             self.state.start = start
             self.state.end = end
 
+    def _zoom_to_data_bounds(self, data):
+        bounds = data.get_chrom_bounds()
+        if not bounds:  # empty dataset
+            return
+
+        with delay_callback(self.state, 'chr', 'start', 'end'):
+            chr, start, end = bounds[0]
+            self.state.chr = chr.lstrip('chr')
+            self.state.start = start
+            self.state.end = start + (end - start) / 100
+
     def get_data_layer_artist(self, layer=None, layer_state=None):
         cls = GenomeProfileLayerArtist if isinstance(layer, BedgraphData) else GenomeLoopLayerArtist
         result = self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
         result.state.add_callback('zorder', self.reflow_tracks)
         result.state.add_callback('visible', self.reflow_tracks)
+
+        # Update view bounds on first layer
+        if not len(self._layer_artist_container):
+            self._zoom_to_data_bounds(layer.data)
+
         return result
 
     def get_subset_layer_artist(self, layer=None, layer_state=None):


### PR DESCRIPTION
This PR adds some logic to set the genome track window boundaries when adding the first data layer. 